### PR TITLE
fix connection error when open stream

### DIFF
--- a/src/com/serotonin/modbus4j/sero/messaging/InputStreamListener.java
+++ b/src/com/serotonin/modbus4j/sero/messaging/InputStreamListener.java
@@ -105,7 +105,7 @@ public class InputStreamListener implements Runnable {
                 }
                 catch (IOException e) {
                     consumer.handleIOException(e);
-                    if (StringUtils.equals(e.getMessage(), "Stream closed."))
+                    if (StringUtils.equals(e.getMessage(), "Stream Closed"))
                         break;
                     if (StringUtils.contains(e.getMessage(), "nativeavailable"))
                         break;

--- a/src/com/serotonin/modbus4j/sero/messaging/StreamTransport.java
+++ b/src/com/serotonin/modbus4j/sero/messaging/StreamTransport.java
@@ -72,6 +72,7 @@ public class StreamTransport implements Transport, Runnable {
      * <p>removeConsumer.</p>
      */
     public void removeConsumer() {
+        if (listener == null) return;
         listener.stop();
         listener = null;
     }


### PR DESCRIPTION
When open a new connection, it will throw a NullPointerException if the serial wire does not connect.
After connection open, if the slave device is not exist, the stream should be closed and stop reading bits from device, fixed in file `src/com/serotonin/modbus4j/sero/messaging/InputStreamListener.java` at line 108.
:)
